### PR TITLE
refactor: all switch cases into one function and stateful inline comment handling

### DIFF
--- a/pkg/unmarshaller.go
+++ b/pkg/unmarshaller.go
@@ -30,6 +30,7 @@ func (m *unmarshaller) unmarshallString(in string) (string, error) {
 }
 
 func (m *unmarshaller) unmarshallBytes(in []byte) (string, error) {
+	in = append(in, byte('\n'))
 	f, err := parser.ParseBytes(in, parser.ParseComments)
 
 	if err != nil {

--- a/pkg/unmarshaller.go
+++ b/pkg/unmarshaller.go
@@ -39,6 +39,8 @@ func (m *unmarshaller) unmarshallBytes(in []byte) (string, error) {
 	for _, d := range f.Docs {
 		docB := d.Body
 		m.unmarshallNode(docB, 0)
+		m.writeInlineComment()
+		m.sb.WriteString("\n")
 	}
 
 	return m.sb.String(), nil
@@ -83,14 +85,14 @@ func (m *unmarshaller) unmarshallObject(o *ast.MappingNode, depth int) {
 
 	c := o.GetComment()
 	if c != nil {
-		fmt.Fprintf(&m.sb, "%s#%s\n", prev, c.GetToken().Value)
+		fmt.Fprintf(&m.sb, "%s#%s\n", pre, c.GetToken().Value)
 	}
 	kvs := o.Values
 	for i, kv := range kvs {
 
 		kvc := kv.GetComment()
 		if kvc != nil {
-			fmt.Fprintf(&m.sb, " #%s\n", kvc.GetToken().Value)
+			fmt.Fprintf(&m.sb, "%s#%s\n", pre, kvc.GetToken().Value)
 		}
 
 		m.sb.WriteString(pre)

--- a/pkg/unmarshaller.go
+++ b/pkg/unmarshaller.go
@@ -1,10 +1,10 @@
 package ksyaml
 
 import (
-	"github.com/goccy/go-yaml/ast"
 	"github.com/goccy/go-yaml/parser"
 
 	"fmt"
+	"github.com/goccy/go-yaml/ast"
 	"strings"
 )
 
@@ -34,143 +34,73 @@ func (m *unmarshaller) unmarshallBytes(in []byte) (string, error) {
 
 	for _, d := range f.Docs {
 		docB := d.Body
-
-		switch docB.(type) {
-
-		case *ast.MappingNode:
-			mnode := docB.(*ast.MappingNode)
-			m.unmarshallMappingNode(mnode, 0)
-
-		case *ast.MappingValueNode:
-			mvnode := docB.(*ast.MappingValueNode)
-			m.unmarshallMappingValue(mvnode, 0)
-
-		case *ast.IntegerNode, *ast.FloatNode, *ast.BoolNode, *ast.StringNode:
-			commAfter := m.unmarshallInlineNode(nil, docB, 0)
-			if commAfter != "" {
-				fmt.Fprintf(&m.sb, " #%s", commAfter)
-			}
-
-		default:
-			fmt.Fprintf(&m.sb,"[x] its  %T %s", docB, docB)
-		}
+		m.unmarshallNode(docB, 0)
 	}
 
 	return m.sb.String(), nil
 }
 
-func (m *unmarshaller) unmarshallMappingNode(data *ast.MappingNode, depth int) {
-	pre := strings.Repeat(m.indentString, depth)
-
-	comm := data.GetComment()
-	if comm != nil {
-		fmt.Fprintf(&m.sb, "%s%s\n", pre, comm)
-	}
-
-	for _, val := range data.Values {
-		m.unmarshallMappingValue(val, depth)
-	}
-}
-
-func (m *unmarshaller) unmarshallMappingValue(data *ast.MappingValueNode, depth int) {
-	pre := strings.Repeat(m.indentString, depth)
-
-	comm := data.GetComment()
-	if data.GetComment() != nil {
-		fmt.Fprintf(&m.sb,"%s%s\n", pre, comm)
-	}
-
-	key := data.Key
-	val := data.Value
-
-	commAfter := ""
-
-	switch val.(type) {
-	case *ast.IntegerNode, *ast.FloatNode, *ast.BoolNode, *ast.StringNode:
-		commAfter = m.unmarshallInlineNode(key, val, depth)
-	case *ast.MappingNode:
-		fmt.Fprintf(&m.sb, "%s%s: {", pre, key.GetToken().Value)
-		comm := key.GetComment()
-		if comm != nil {
-			fmt.Fprintf(&m.sb," %s", comm)
-		}
-		m.sb.WriteString("\n")
-		m.unmarshallMappingNode(val.(*ast.MappingNode), depth+1)
-		m.sb.WriteString(pre + "}")
+func (m *unmarshaller) unmarshallNode(n ast.Node, depth int) {
+	switch v := n.(type) {
+	case *ast.BoolNode, *ast.FloatNode, *ast.IntegerNode, *ast.NullNode, *ast.StringNode:
+		m.unmarshallValue(v, depth)
 	case *ast.MappingValueNode:
-		fmt.Fprintf(&m.sb, "%s%s: {\n", pre, key)
-		m.unmarshallMappingValue(val.(*ast.MappingValueNode), depth+1)
-		m.sb.WriteString(pre + "}")
-	case *ast.SequenceNode:
-		fmt.Fprintf(&m.sb, "%s%s: [\n", pre, key)
-		m.unmarshallSequenceNode(val.(*ast.SequenceNode), depth+1)
-		m.sb.WriteString(pre + "]")
+		m.unmarshallKeyValue(v, depth+1)
+	case *ast.MappingNode:
+		m.unmarshallObject(v, depth)
 	default:
-		fmt.Fprintf(&m.sb,"[x] %s %s: %T", pre, key, val)
+		fmt.Fprintf(&m.sb, "[x](%T)%s", n, n)
 	}
 
-	if depth > 0 {
-		m.sb.WriteString(",")
-	}
-	if commAfter != "" {
-		fmt.Fprintf(&m.sb, " #%s", commAfter)
-	}
-	m.sb.WriteString("\n")
 }
 
-func (m *unmarshaller) unmarshallInlineNode(key, value ast.Node, depth int) string {
+func (m *unmarshaller) unmarshallKey(k ast.Node, depth int) {
 	pre := strings.Repeat(m.indentString, depth)
-
 	m.sb.WriteString(pre)
-	val := value.GetToken().Value
-	if key != nil {
-		fmt.Fprintf(&m.sb, "%s: ", key.GetToken().Value)
+	m.sb.WriteString(k.GetToken().Value)
+	m.sb.WriteString(": ")
+
+	comm := k.GetComment()
+	if comm != nil {
+		fmt.Fprintf(&m.sb, " #%s", comm.GetToken().Value)
 	}
-	switch value.(type) {
-	case *ast.StringNode:
-		fmt.Fprintf(&m.sb, "\"%s\"", val)
-	default:
-		fmt.Fprintf(&m.sb, "%s", val)
-	}
-	if value.GetComment() != nil {
-		return value.GetComment().GetToken().Value
-	}
-	return ""
 }
 
-func (m *unmarshaller) unmarshallSequenceNode(data *ast.SequenceNode, depth int) {
-	pre := strings.Repeat(m.indentString, depth)
+func (m *unmarshaller) unmarshallObject(o *ast.MappingNode, depth int) {
 
-	comm := data.GetComment()
-	if comm != nil {
-		fmt.Fprintf(&m.sb, "%s%s\n", pre, comm)
+	if depth != 0 {
+		m.sb.WriteString("{\n")
 	}
-
-	commAfter := ""
-	for i, val := range data.Values {
-		switch val.(type) {
-		case *ast.IntegerNode, *ast.FloatNode, *ast.BoolNode, *ast.StringNode:
-			commAfter = m.unmarshallInlineNode(nil, val, depth)
-		case *ast.MappingNode:
-			m.sb.WriteString(pre + "{\n")
-			m.unmarshallMappingNode(val.(*ast.MappingNode), depth+1)
-			m.sb.WriteString(pre + "}")
-		case *ast.MappingValueNode:
-			m.sb.WriteString(pre + "{\n")
-			m.unmarshallMappingValue(val.(*ast.MappingValueNode), depth)
-			m.sb.WriteString(pre + "}")
-		case *ast.SequenceNode:
-			m.sb.WriteString(pre + "[\n")
-			m.unmarshallSequenceNode(val.(*ast.SequenceNode), depth+1)
-			m.sb.WriteString(pre + "]")
-		}
-		if i != len(data.Values)-1 {
+	v := o.Values
+	for i, kv := range v {
+		m.unmarshallKeyValue(kv, depth)
+		if i != len(v)-1 && depth != 0 {
 			m.sb.WriteString(",")
 		}
-		if commAfter != "" {
-			fmt.Fprintf(&m.sb, " #%s", commAfter)
-		}
 		m.sb.WriteString("\n")
 	}
+	if depth != 0 {
+		m.sb.WriteString("}\n")
+	}
+}
 
+func (m *unmarshaller) unmarshallKeyValue(n *ast.MappingValueNode, depth int) {
+	k := n.Key
+	v := n.Value
+	m.unmarshallKey(k, depth)
+	m.unmarshallNode(v, depth+1)
+}
+
+func (m *unmarshaller) unmarshallValue(v ast.Node, depth int) {
+
+	vs := v.GetToken().Value
+	switch v.(type) {
+	case *ast.StringNode:
+		fmt.Fprintf(&m.sb, `"%s"`, vs)
+	default:
+		m.sb.WriteString(vs)
+	}
+	if v.GetComment() != nil {
+		fmt.Fprintf(&m.sb, " #%s", v.GetComment().GetToken().Value)
+	}
 }

--- a/pkg/unmarshaller.go
+++ b/pkg/unmarshaller.go
@@ -48,10 +48,11 @@ func (m *unmarshaller) unmarshallNode(n ast.Node, depth int) {
 		m.unmarshallKeyValue(v, depth+1)
 	case *ast.MappingNode:
 		m.unmarshallObject(v, depth)
+	case *ast.SequenceNode:
+		m.unmarshallArray(v, depth)
 	default:
 		fmt.Fprintf(&m.sb, "[x](%T)%s", n, n)
 	}
-
 }
 
 func (m *unmarshaller) unmarshallKey(k ast.Node, depth int) {
@@ -80,7 +81,7 @@ func (m *unmarshaller) unmarshallObject(o *ast.MappingNode, depth int) {
 		m.sb.WriteString("\n")
 	}
 	if depth != 0 {
-		m.sb.WriteString("}\n")
+		m.sb.WriteString("}")
 	}
 }
 
@@ -103,4 +104,17 @@ func (m *unmarshaller) unmarshallValue(v ast.Node, depth int) {
 	if v.GetComment() != nil {
 		fmt.Fprintf(&m.sb, " #%s", v.GetComment().GetToken().Value)
 	}
+}
+
+func (m *unmarshaller) unmarshallArray(n *ast.SequenceNode, depth int) {
+	m.sb.WriteString("[\n")
+	v := n.Values
+	for i, vv := range v {
+		m.unmarshallNode(vv, depth+1)
+		if i != len(v)-1 {
+			m.sb.WriteString(",")
+		}
+		m.sb.WriteString("\n")
+	}
+	m.sb.WriteString("]\n")
 }

--- a/pkg/unmarshaller.go
+++ b/pkg/unmarshaller.go
@@ -117,7 +117,8 @@ func (m *unmarshaller) unmarshallArray(n *ast.SequenceNode, depth int) {
 		}
 		m.sb.WriteString("\n")
 	}
-	m.sb.WriteString("]\n")
+	prec := strings.Repeat(m.indentString, max(0, depth-1))
+	fmt.Fprintf(&m.sb, "%s]", prec)
 }
 
 func max(a, b int) int {

--- a/pkg/unmarshaller.go
+++ b/pkg/unmarshaller.go
@@ -70,8 +70,18 @@ func (m *unmarshaller) unmarshallObject(o *ast.MappingNode, depth int) {
 	if depth != 0 {
 		m.sb.WriteString("{\n")
 	}
+	c := o.GetComment()
+	if c != nil {
+		fmt.Fprintf(&m.sb, "%s#%s\n", pre, c.GetToken().Value)
+	}
 	v := o.Values
 	for i, kv := range v {
+
+		kvc := kv.GetComment()
+		if kvc != nil {
+			fmt.Fprintf(&m.sb, "%s#%s\n", pre, kvc.GetToken().Value)
+		}
+
 		m.sb.WriteString(pre)
 		m.unmarshallNode(kv, depth+1)
 		if i != len(v)-1 && depth != 0 {
@@ -89,7 +99,7 @@ func (m *unmarshaller) unmarshallKeyValue(n *ast.MappingValueNode, depth int) {
 	k := n.Key
 	v := n.Value
 	m.unmarshallKey(k, depth)
-	m.unmarshallNode(v, depth)
+	m.unmarshallNode(v, depth+1)
 }
 
 func (m *unmarshaller) unmarshallValue(v ast.Node, depth int) {
@@ -107,7 +117,14 @@ func (m *unmarshaller) unmarshallValue(v ast.Node, depth int) {
 
 func (m *unmarshaller) unmarshallArray(n *ast.SequenceNode, depth int) {
 	pre := strings.Repeat(m.indentString, depth)
+
 	m.sb.WriteString("[\n")
+
+	c := n.GetComment()
+	if c != nil {
+		fmt.Fprintf(&m.sb, "%s#%s\n", pre, c.GetToken().Value)
+	}
+
 	v := n.Values
 	for i, vv := range v {
 		m.sb.WriteString(pre)

--- a/pkg/unmarshaller.go
+++ b/pkg/unmarshaller.go
@@ -101,6 +101,7 @@ func (m *unmarshaller) unmarshallObject(o *ast.MappingNode, depth int) {
 		v := kv.Value
 		m.unmarshallKey(k, depth)
 		m.unmarshallNode(v, depth+1)
+		m.writeInlineComment()
 
 		if i != len(kvs)-1 && depth != 0 {
 			m.sb.WriteString(",")

--- a/pkg/unmarshaller_test.go
+++ b/pkg/unmarshaller_test.go
@@ -182,8 +182,8 @@ key: { # comment
 			input: `
 key:
   arr:
-	- 1
-	- string
+   - 1
+   - string
 `,
 			expected: `
 key: {
@@ -197,8 +197,9 @@ key: {
 			name: "Nested Object",
 			input: `
 key:
-   key:
-	  key: value`,
+  key:
+    key: value
+`,
 			expected: `
 key: {
  key: {


### PR DESCRIPTION
I refactored all the switch cases into one function `unmarshallNode`.
I also changed the way ks-yaml handles inline comment using state
```go
	inlineComment    string
	hasInlineComment bool
```

`hasInlineComment` will be set to true and `inlineComment `will be set to the comment.
This comment will be printed out in the next appropriate place with the function `writeInlineComment`
