### PR TITLE
fix: literal string bugs #11 & #8

### DIFF
--- a/unmarshaller.go
+++ b/unmarshaller.go
@@ -134,9 +134,12 @@ func (m *unmarshaller) unmarshallLiteral(n *ast.LiteralNode, depth int) {
 	}
 
 	origin := n.Value.GetToken().Origin
+	if depth > 0 {
+		origin = n.Value.GetToken().Value
+	}
 	lit := strings.TrimSpace(origin)
 
-	fmt.Fprintf(&m.sb, `"%s"`, lit)
+	fmt.Fprintf(&m.sb, `%q`, lit)
 	if n.GetComment() != nil {
 		c := n.GetComment().GetToken().Value
 		m.addInlineComment(c)

--- a/unmarshaller.go
+++ b/unmarshaller.go
@@ -124,8 +124,6 @@ func (m *unmarshaller) unmarshallSpecialMathNode(n ast.Node, depth int) {
 	}
 }
 
-// known BUG white spaces in | literal on depth > 0
-// #8 or github.com/kambi-ng/ks-yaml/issues/7#issuecomment-1181629097_
 func (m *unmarshaller) unmarshallLiteral(n *ast.LiteralNode, depth int) {
 
 	if depth <= 1 {

--- a/unmarshaller.go
+++ b/unmarshaller.go
@@ -207,7 +207,7 @@ func (m *unmarshaller) unmarshallValue(v ast.Node, depth int) {
 	vs := v.GetToken().Value
 	switch v.(type) {
 	case *ast.StringNode:
-		fmt.Fprintf(&m.sb, `"%s"`, vs)
+		fmt.Fprintf(&m.sb, `%q`, vs)
 	default:
 		m.sb.WriteString(vs)
 	}

--- a/unmarshaller_test.go
+++ b/unmarshaller_test.go
@@ -318,8 +318,7 @@ key:
     right?`,
 			expected: `
 key: {
- litral: "this is literal
-    right?" # comment
+ litral: "this is literal\nright?" # comment
 }`,
 		},
 		{
@@ -331,8 +330,7 @@ key:
    right?`,
 			expected: `
 key: [
- "this is literal
-   right?" # comment
+ "this is literal\nright?" # comment
 ]`,
 		},
 		{
@@ -346,9 +344,7 @@ key:
   bool: true`,
 			expected: `
 key: {
- litral: "this is literal
-
-    right?", # comment
+ litral: "this is literal  right?", # comment
  bool: true
 }`,
 		},
@@ -362,8 +358,7 @@ key:
   - true`,
 			expected: `
 key: [
- "this is literal
-    right?", # comment
+ "this is literal right?", # comment
  true
 ]`,
 	 	},


### PR DESCRIPTION
Literal string now follows the specification.
and
Qoutes inside literal are now escaped.

Issues #11 and #8 